### PR TITLE
Fix to improper sizing of container in LoginView and ScanView

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <div 
     id="flavorpal-app-container" 
-    class="max-w-md mx-auto min-h-screen bg-flavorpal-gray-light font-sans overflow-hidden relative flex flex-col"
+    class="max-w-md mx-auto h-dvh bg-flavorpal-gray-light font-sans overflow-hidden relative flex flex-col"
     :style="{ 
-      paddingTop: 'env(safe-area-inset-top)', 
-      paddingBottom: !showBottomNavComputed ? 'env(safe-area-inset-bottom)' : '0px' 
+      // paddingTop: 'env(safe-area-inset-top)', 
+      // paddingBottom: !showBottomNavComputed ? 'env(safe-area-inset-bottom)' : '0px' 
     }"
   >
     <main 

--- a/frontend/src/views/Auth/LoginView.vue
+++ b/frontend/src/views/Auth/LoginView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-flavorpal-green to-emerald-400 p-4 sm:p-6 antialiased">
+  <div class="flex flex-col items-center justify-center h-full bg-gradient-to-br from-flavorpal-green to-emerald-400 p-4 sm:p-6 antialiased">
     <div class="w-full max-w-sm bg-white p-6 sm:p-10 rounded-2xl shadow-2xl transform transition-all hover:scale-105 duration-300 ease-in-out">
       <div class="text-center mb-8">
         <div class="inline-block p-3 bg-flavorpal-green rounded-full mb-4 shadow-lg">

--- a/frontend/src/views/ScanView.vue
+++ b/frontend/src/views/ScanView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col min-h-screen bg-gray-800 text-white relative overflow-hidden">
+  <div class="flex flex-col h-full bg-gray-800 text-white relative overflow-hidden">
     <header 
       v-if="!isCameraActive && scanStore.currentStage !== 'analyzing'" 
       class="absolute top-0 left-0 z-30 p-3 sm:p-4 w-full"


### PR DESCRIPTION
Currently the LoginView and the ScanView overflows slightly and cause a scroll bar to appear.

The addressing of this issue:
- Use `h-dvh` to dynamically adapt to the window height (either in PWA or safari mode). It can now confine to Safari bars and in PWA mode (standalone, adapted for dynamic island)
- Use `h-full` instead of `min-h-screen` to confine ScanView into the container so the button at the bottom does not overflow.

Tested on iOS 18.4.1